### PR TITLE
Bug fix splitting intervals

### DIFF
--- a/mkalgo/mk.py
+++ b/mkalgo/mk.py
@@ -35,6 +35,11 @@ class base(object):
         for i in range(0, lts, self.l):
             splits.append([i, i+self.l])
             m += 1
+          
+        if m * self.l > lts:
+            splits = splits[:m-1]
+            m = m -1
+            
         return splits, m
 
 


### PR DESCRIPTION
When you split the time series into the subsequence length of the motif you're considering also points which don't exist in the time series.  Example: if the time series has 80.001 points and I choose a subsequence length of 200, you will split the time series into m intervals: from [0,200],[200,400] and so on until [79.800, 80.000] and it remains out a point and you will have another interval which is [80.001, 80.200] which is wrong because it contains only one real number. As a result you will find a motif which is not a real motif because the distance will be calculated between points that do not exist. My solution is to delete the last interval if it creates an interval that doesn't exist.